### PR TITLE
[#2] Fix diameter dimensions of Rocketarium BT-60

### DIFF
--- a/orc/ROCKETARIUM.ORC
+++ b/orc/ROCKETARIUM.ORC
@@ -530,8 +530,8 @@ Using this file:
 			<PartNumber>BT-60, White, 6"</PartNumber>
 			<Description>BT-60 Body Tube. 6" White, PN BT-60, White, 6"</Description>
 			<Material Type="BULK">Paper, spiral kraft glassine, bulk</Material>
-			<InsideDiameter Unit="in">3.9</InsideDiameter>
-			<OutsideDiameter Unit="in">4.024</OutsideDiameter>
+			<InsideDiameter Unit="in">1.595</InsideDiameter>
+			<OutsideDiameter Unit="in">1.637</OutsideDiameter>
 			<Length Unit="in">6</Length>
 		</BodyTube>
 		<BodyTube>
@@ -539,8 +539,8 @@ Using this file:
 			<PartNumber>BT-60, White, 9"</PartNumber>
 			<Description>BT-60 Body Tube. 9" White, PN BT-60, White, 9"</Description>
 			<Material Type="BULK">Paper, spiral kraft glassine, bulk</Material>
-			<InsideDiameter Unit="in">3.9</InsideDiameter>
-			<OutsideDiameter Unit="in">4.024</OutsideDiameter>
+			<InsideDiameter Unit="in">1.595</InsideDiameter>
+			<OutsideDiameter Unit="in">1.637</OutsideDiameter>
 			<Length Unit="in">9</Length>
 		</BodyTube>
 		<BodyTube>
@@ -548,8 +548,8 @@ Using this file:
 			<PartNumber>BT-60, White, 11.4"</PartNumber>
 			<Description>BT-60 Body Tube. 11.4" White, PN BT-60, White, 11.4"</Description>
 			<Material Type="BULK">Paper, spiral kraft glassine, bulk</Material>
-			<InsideDiameter Unit="in">3.9</InsideDiameter>
-			<OutsideDiameter Unit="in">4.024</OutsideDiameter>
+			<InsideDiameter Unit="in">1.595</InsideDiameter>
+			<OutsideDiameter Unit="in">1.637</OutsideDiameter>
 			<Length Unit="in">11.4</Length>
 		</BodyTube>
 		<BodyTube>
@@ -557,8 +557,8 @@ Using this file:
 			<PartNumber>BT-60, White, 16"</PartNumber>
 			<Description>BT-60 Body Tube. 16" White, PN BT-60, White, 16"</Description>
 			<Material Type="BULK">Paper, spiral kraft glassine, bulk</Material>
-			<InsideDiameter Unit="in">3.9</InsideDiameter>
-			<OutsideDiameter Unit="in">4.024</OutsideDiameter>
+			<InsideDiameter Unit="in">1.595</InsideDiameter>
+			<OutsideDiameter Unit="in">1.637</OutsideDiameter>
 			<Length Unit="in">16</Length>
 		</BodyTube>
 		<!-- Motor tubes -->


### PR DESCRIPTION
This PR fixes #2. The inner and outer diameter of the BT-60 tube were wrong. New values taken from the Rocketarium website:
<img width="1185" alt="image" src="https://github.com/user-attachments/assets/beea3add-788b-4e5f-9a6b-fddeb83c077d" />
